### PR TITLE
fix: ensures switch default value isn't set until known

### DIFF
--- a/website/components/Layout/Header.tsx
+++ b/website/components/Layout/Header.tsx
@@ -37,7 +37,9 @@ const Header: React.FunctionComponent<{}> = () => {
       <Link href={linkToLanding()} passHref>
         <A>Potly</A>
       </Link>
-      <Switch checked={mode === 'dark'} onClick={toggleDarkMode} />
+      {mode && (
+        <Switch defaultChecked={mode === 'dark'} onClick={toggleDarkMode} />
+      )}
       {user ? (
         <AvatarWrapper>
           {/* TODO: Bring back the profile image url */}

--- a/website/hooks/useDarkMode.ts
+++ b/website/hooks/useDarkMode.ts
@@ -1,7 +1,13 @@
-import { darkTheme, lightTheme, Theme } from '@/components/Layout/ThemeProvider/theme'
+import {
+  darkTheme,
+  lightTheme,
+  Theme,
+} from '@/components/Layout/ThemeProvider/theme'
 import { useEffect, useState } from 'react'
 
 type Mode = 'light' | 'dark'
+
+const DEFAULT_MODE: Mode = 'dark'
 
 interface ReturnType {
   mode: Mode
@@ -10,7 +16,7 @@ interface ReturnType {
 }
 
 function useDarkMode(): ReturnType {
-  const [mode, setMode] = useState<Mode>('dark')
+  const [mode, setMode] = useState<Mode | null>(null)
 
   const toggleDarkMode = () => {
     const newMode = mode === 'light' ? 'dark' : 'light'


### PR DESCRIPTION
Theme switch would always be passed the default theme mode as the initial value from the hook was always the default. This fixes that.